### PR TITLE
Fix macOS mouse tracking in hardened OBS builds

### DIFF
--- a/zoom-follow-mouse-and-more-eg.lua
+++ b/zoom-follow-mouse-and-more-eg.lua
@@ -290,19 +290,38 @@ local function init_macos_ffi()
     
     local success, err = pcall(function()
         ffi.cdef[[
-            typedef struct CGDirectDisplayID *CGDirectDisplayID;
+            typedef double CGFloat;
+            typedef uint32_t CGDirectDisplayID;
             typedef uint32_t CGDisplayCount;
-            typedef struct CGRect CGRect;
-            typedef struct CGPoint CGPoint;
+            typedef int32_t CGError;
+            typedef struct {
+                CGFloat x;
+                CGFloat y;
+            } CGPoint;
+            typedef struct {
+                CGFloat width;
+                CGFloat height;
+            } CGSize;
+            typedef struct {
+                CGPoint origin;
+                CGSize size;
+            } CGRect;
             
-            int CGGetActiveDisplayList(CGDisplayCount maxDisplays, CGDirectDisplayID *activeDisplays, CGDisplayCount *displayCount);
+            CGError CGGetActiveDisplayList(CGDisplayCount maxDisplays, CGDirectDisplayID *activeDisplays, CGDisplayCount *displayCount);
             CGRect CGDisplayBounds(CGDirectDisplayID display);
             CGPoint CGEventGetLocation(void* event);
             void* CGEventCreate(void* source);
             void CFRelease(void* cf);
         ]]
         
-        ffi_platform.core_graphics = ffi.load("CoreGraphics", true)
+        -- A bare "CoreGraphics" name becomes a relative libCoreGraphics.dylib
+        -- lookup, which hardened/notarized OBS builds reject on modern macOS.
+        -- The canonical absolute framework path is resolved by dyld even when
+        -- the framework binary itself lives in the shared cache.
+        ffi_platform.core_graphics = ffi.load(
+            "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics",
+            true
+        )
     end)
     
     if not success then


### PR DESCRIPTION
## What this resolves

Mouse-centered zoom and Follow were unavailable on current macOS/OBS builds because the script could not initialize CoreGraphics:

```text
dlopen(libCoreGraphics.dylib): relative path not allowed in hardened program
```

The script would consequently report that the global mouse position could not be read and fall back to the center or top-left of the capture.

This change restores cursor-position tracking and monitor detection on macOS by:

- loading CoreGraphics through Apple's canonical absolute framework path, which works inside hardened and notarized OBS builds
- correcting the LuaJIT FFI definitions for `CGDirectDisplayID`, `CGError`, `CGPoint`, `CGSize`, and `CGRect` to match Apple's 64-bit ABI
- preserving the existing centered-zoom fallback when platform initialization genuinely fails

## Root cause

`ffi.load("CoreGraphics", true)` becomes a relative `libCoreGraphics.dylib` lookup. Modern hardened OBS processes reject that relative lookup.

The previous declarations also modeled `CGDirectDisplayID` as a pointer and left the geometry structures incomplete. Those definitions do not match CoreGraphics and can break monitor enumeration and cursor-location calls even after the framework loads.

## Validation

Tested end to end on:

- macOS 26.5.1 on Apple Silicon
- OBS Studio 32.2.0
- two displays
- Retina Display Capture source at 3456x2234

After reloading the patched script, OBS:

- initialized without the CoreGraphics `dlopen` error
- reported `Detected 2 monitor(s)`
- read the global cursor position
- zoomed at the cursor instead of the center/top-left
- updated crop coordinates continuously while Follow was active

Additional checks:

- confirmed the committed file exactly matches the runtime-tested script
- checked the FFI declarations against the installed macOS SDK headers
- loaded the absolute framework and resolved every required symbol
- ran `git diff --check`

Fixes #22

Related historical macOS reports: #8, #9
